### PR TITLE
Corrected commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Aura.UI.
 
 Open the terminal on the root folder of your project and write <br/>
 ```cmd
-dotnet package Aura.UI --version 0.1.4.2
+dotnet add package Aura.UI --version 0.1.4.2
 ```
 
 And don't forget install the Styles
 ```cmd
-dotnet package Aura.UI.FluentTheme --version 0.1.4.2
+dotnet add package Aura.UI.FluentTheme --version 0.1.4.2
 ```
 
 


### PR DESCRIPTION
```
[zekiah @ arch]$ dotnet package Aura.UI --version 0.1.4.2
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-package does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
  
[zekiah @ arch]$ dotnet add package Aura.UI --version 0.1.4.2
  Determining projects to restore...
  Writing /tmp/tmpj4ySLw.tmp
```

"dotnet package" will return an error, as it is not a command, so dotnet add pacakge should be used.
